### PR TITLE
Beta 3 Fixes

### DIFF
--- a/direct-stripe.php
+++ b/direct-stripe.php
@@ -75,6 +75,14 @@ if ( ! class_exists( 'DirectStripe' ) ) :
         const version = '3.0.0-beta';
 
         /**
+         * Stripe Api Version used by this plugin
+         *
+         * @since 3.0.0
+         * @var string
+         */
+        const stripe_api_version = "2019-09-09";
+
+        /**
          * Plugin Textdomain.
          *
          * @since 2.0.0
@@ -95,6 +103,7 @@ if ( ! class_exists( 'DirectStripe' ) ) :
             $this->init_hooks();
             $this->activation_hooks();
             $this->register_stripe_app();
+            $this->set_stripe_api_version();
         }
 
         /**
@@ -108,6 +117,15 @@ if ( ! class_exists( 'DirectStripe' ) ) :
                 self::version,
                 "https://wordpress.org/plugins/direct-stripe/"
             );
+        }
+
+        /**
+        * Set Stripe Api Version https://stripe.com/docs/api/versioning
+        *
+        * @since 3.0.0
+        */
+        function set_stripe_api_version() {
+            \Stripe\Stripe::setApiVersion(self::stripe_api_version);
         }
 
         function activation_hooks() {

--- a/process/ds_process_functions.php
+++ b/process/ds_process_functions.php
@@ -552,7 +552,7 @@ class ds_process_functions
                     'action_type'   => 'incomplete'
                 )
             );
-        } else if ($intent->status === "succeeded" || $intent->status === "requires_capture") {
+        } else if ($intent->status === "succeeded" || $intent->status === "requires_capture" || $intent->status === "active") {
             // Process completed get answer
             self::pre_process_answer($intent, $resultData);
         } else {


### PR DESCRIPTION
It would be more prudent to specify the version of the Stripe API this plugin need to use. To avoid depreciation bugs as I was referring here: https://wordpress.org/support/topic/beta-tests-results/. Indeed the modifications made to the plugin for version 3 make it incompatible with the 2017 version of the Stripe API, wich is - I assumme - still the default version for a lot of Stripe's customers.