### PR TITLE
Fix display amount type

### DIFF
--- a/includes/ds-data.php
+++ b/includes/ds-data.php
@@ -60,7 +60,7 @@ $directStripeAttrValues = shortcode_atts( array(
 	'rememberme'        =>  ''
 ), $atts, 'direct_stripe' );
 
-
+$directStripeAttrValues['display_amount'] = filter_var( $directStripeAttrValues['display_amount'], FILTER_VALIDATE_BOOLEAN );
 
 /*
  * Check if the shortcode is given a value argument


### PR DESCRIPTION
Fixes #144

Other items look like they could use the same treatment, and other lines like `'shipping'              =>  !empty($directStripeAttrValues['shipping']) ? $directStripeAttrValues['shipping'] : 'false',` with false entered as a string look like they should be booleans instead, but I only changed the one I know was required. 

Result with that added line:

![image](https://user-images.githubusercontent.com/11990914/65167938-ca1be300-da43-11e9-8941-6d50ff39a8be.png)
